### PR TITLE
Makefile: Add LDFLAGS to prepare rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ dump.c: prepare
 	./prepare
 
 prepare: prepare.o q3cube.o q3c_poly.o
-	$(CC) prepare.o q3cube.o q3c_poly.o $(MYBINLIBS) -o $@
-              
+	$(CC) $(LDFLAGS) prepare.o q3cube.o q3c_poly.o $(MYBINLIBS) -o $@
+
 gen_data: gen_data.c
 	$(CC) $< $(CPPFLAGS) $(MYBINLIBS) -o $@
 


### PR DESCRIPTION
Debian's build log hardening check (blhc) noticed missing linker options
(-Wl,-z,relro -Wl,-z,now), which normally come from LDFLAGS.