### PR TITLE
Applying patch to Makefile for PostgreSQL >= v12 and macOS.

### DIFF
--- a/q3c.control
+++ b/q3c.control
@@ -1,3 +1,3 @@
 comment = 'q3c sky indexing plugin'
-default_version = '1.8.0'
+default_version = '1.8.1'
 module_pathname = '$libdir/q3c'


### PR DESCRIPTION
Second try. This patch actively tests for macOS and PostgreSQL v12+. Also fixed the evaluation of the `$PGVERNEW` variable; bash cannot evaluate numbers that aren't integers, so `bc` is used. Whoever created the Makefile syntax has a lot to answer for.