### PR TITLE
Install docs to non-generic name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ EXTVERSION := $(shell grep default_version $(EXTENSION).control | \
 		 sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
 
 
-DOCS = README.md
+DOCS = q3c.md
 OBJS = dump.o q3c.o q3c_poly.o q3cube.o
 MODULE_big = q3c
 DATA = $(wildcard scripts/*sql)

--- a/q3c.md
+++ b/q3c.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Previously, README.md was installed to .../doc/extension/README.md which conflicts with other extensions doing the same mistake. Fix by adding a symlink q3c.md and using that in DOCS. Keep the original README.md name to please GitHub.

Debian Bug: https://bugs.debian.org/1073800